### PR TITLE
added callbacks for erixon::smart_supply mod

### DIFF
--- a/ui/addons/ego_detailmonitor/menu_map.xpl
+++ b/ui/addons/ego_detailmonitor/menu_map.xpl
@@ -1,4 +1,4 @@
-
+﻿
 -- section == gMain_map
 -- param == { 0, 0, showzone, focuscomponent [, history] [, mode, modeparam] [, showmultiverse] [, focusoffset] }
  
@@ -14555,6 +14555,13 @@ function menu.setupLoadoutInfoSubmenuRows(mode, inputtable, inputobject, instanc
 			end
 		end
 	end
+
+    if callbacks["setupLoadoutInfoSubmenuRows_rows_between_ammo_and_countermeasures"] then
+        for _, callback in ipairs(callbacks["setupLoadoutInfoSubmenuRows_rows_between_ammo_and_countermeasures"]) do
+            callback(mode, inputtable, inputobject)
+        end
+    end
+
 	if mode == "ship" then
 		-- countermeasures
 		local numcountermeasuretypes = C.GetNumAllCountermeasures(inputobject)

--- a/ui/addons/ego_detailmonitor/menu_ship_configuration.xpl
+++ b/ui/addons/ego_detailmonitor/menu_ship_configuration.xpl
@@ -1236,6 +1236,13 @@ function menu.buttonSave(overwrite)
 		Helper.callLoadoutFunction(menu.upgradeplan, nil, function (loadout, _) return C.SaveLoadout2(macro, loadout, "local", loadoutid or "player", loadoutid ~= nil, menu.loadoutName, "") end, nil, "UILoadout2")
 		menu.getPresetLoadouts()
 	end
+
+	if callbacks["buttonSave_after_loadout_saved"] then
+		for _, callback in ipairs(callbacks["buttonSave_after_loadout_saved"]) do
+			callback(overwrite, macro)
+		end
+	end
+
 	menu.closeContextMenu()
 	menu.displayMenu()
 end
@@ -2067,7 +2074,16 @@ function menu.buttonAddPurchase(hasupgrades, hasrepairs)
 		groupstates = menu.objectgroup.states
 	end
 
-	table.insert(menu.shoppinglist, { objectgroup = objectgroup, groupstates = groupstates, object = object, macro = menu.macro, hasupgrades = hasupgrades, upgradeplan = menu.upgradeplan, crew = menu.crew, settings = menu.settings, amount = 1, price = menu.total, crewprice = menu.crewtotal, duration = menu.duration, warnings = menu.warnings, customshipname = menu.customshipname, useloadoutname = menu.useloadoutname, loadoutName = menu.loadoutName, playershipname = menu.playershipname })
+	local shoppingEntry = { objectgroup = objectgroup, groupstates = groupstates, object = object, macro = menu.macro, hasupgrades = hasupgrades, upgradeplan = menu.upgradeplan, crew = menu.crew, settings = menu.settings, amount = 1, price = menu.total, crewprice = menu.crewtotal, duration = menu.duration, warnings = menu.warnings, customshipname = menu.customshipname, useloadoutname = menu.useloadoutname, loadoutName = menu.loadoutName, playershipname = menu.playershipname }
+
+	-- updates shoppingEntry with required data after button "add to shopping list" pressed
+	if callbacks["buttonAddPurchase_update_shopping_list_table"] then
+		for _, callback in ipairs(callbacks["buttonAddPurchase_update_shopping_list_table"]) do
+			callback(shoppingEntry)
+		end
+	end
+
+	table.insert(menu.shoppinglist,shoppingEntry)
 	menu.object = 0
 	menu.objectgroup = nil
 	menu.damagedcomponents = {}
@@ -10318,6 +10334,12 @@ function menu.repairandupgrade(shoppinglistentry, object, macro, hasupgrades, ha
 			if (buildtaskid ~= 0) and haspaid then
 				C.SetBuildTaskTransferredMoney(buildtaskid, objectprice and (objectprice + objectcrewprice) or haspaid)
 			end
+
+            if callbacks["repairandupgrade_after_build_order_created"] then
+                for _, callback in ipairs(callbacks["repairandupgrade_after_build_order_created"]) do
+                    callback(shoppinglistentry, object, buildtaskid)
+                end
+            end
 		end
 	end
 end


### PR DESCRIPTION
Hello, 

I would like to add necessary callbacks for upcoming mod.

Idea of mod is to add ui support to choose saved presets for the ships (same which you able to save/apply in ship building window).
Mod updates vanila 'interrupt.restock.xml' so script will try to restock missiles/drones/deployable/countermeasure according to choosen preset.

If you need any detail, don't hesitate to ask me.
