### PR TITLE
feat(menu_map): add info submenu callbacks for left and right frames Post beta 3 features

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.lua]
+indent_style = tab
+indent_size = 4

--- a/ui/addons/ego_detailmonitor/menu_docked.xpl
+++ b/ui/addons/ego_detailmonitor/menu_docked.xpl
@@ -205,6 +205,7 @@ local function init()
 	registerForEvent("gameplanchange", getElement("Scene.UIContract"), menu.onGamePlanChange)
 	RegisterEvent("conversationCancelled", menu.onConvEnds)
 	RegisterEvent("conversationFinished", menu.onConvEnds)
+	RegisterEvent("cinematic_camera_deactivated", menu.checkActivation)
 
 	-- kuertee start:
 	menu.init_kuertee()
@@ -237,11 +238,15 @@ end
 
 function menu.onConvEnds()
 	if not Helper.hasConversationReturnHandler then
-		local controlpost = ffi.string(C.GetPlayerCurrentControlGroup())
-		local occupiedship = ConvertStringTo64Bit(tostring(C.GetPlayerOccupiedShipID()))
-		if ((occupiedship ~= 0) and GetComponentData(occupiedship, "isdocked")) or ((controlpost ~= "") and (controlpost ~= "pilotcontrol")) then
-			OpenMenu("DockedMenu", { 0, 0 }, nil)
-		end
+		menu.checkActivation()
+	end
+end
+
+function menu.checkActivation()
+	local controlpost = ffi.string(C.GetPlayerCurrentControlGroup())
+	local occupiedship = ConvertStringTo64Bit(tostring(C.GetPlayerOccupiedShipID()))
+	if ((occupiedship ~= 0) and GetComponentData(occupiedship, "isdocked")) or ((controlpost ~= "") and (controlpost ~= "pilotcontrol")) then
+		OpenMenu("DockedMenu", { 0, 0 }, nil)
 	end
 end
 

--- a/ui/addons/ego_detailmonitor/menu_map.xpl
+++ b/ui/addons/ego_detailmonitor/menu_map.xpl
@@ -8706,6 +8706,15 @@ function menu.createPropertyOwned(frame, instance)
 		maxNumCategoryColumns = Helper.maxTableCols
 	end
 	local numOfSorterColumns = 4 -- "sort by", "size", "name", "hull"
+	--kuertee start: extra sort by distance
+	-- "distance from player"
+	numOfSorterColumns = numOfSorterColumns + 1
+	if menu.infoSubmenuObject then
+		-- "distance from object"
+		numOfSorterColumns = numOfSorterColumns + 1
+	end
+	--kuertee end: extra sort by distance
+
 	local colSpanPerSorterColumn = math.floor(maxNumCategoryColumns / numOfSorterColumns)
 	local tabtable = frame:addTable(maxNumCategoryColumns, {
 		tabOrder = 2,
@@ -8834,7 +8843,7 @@ function menu.createPropertyOwned(frame, instance)
 		--kuertee start: extra sort by distance
 		-- "distance from player"
 		local buttonLabel = ffi.string(C.GetPlayerName ())
-		sorterColumn = 3
+		sorterColumn = 5
 		tableColumn = (sorterColumn - 1) * colSpanPerSorterColumn + 1
 		local button = row[tableColumn]:setColSpan(colSpanPerSorterColumn):createButton({ scaling = false, height = buttonheight }):setText(buttonLabel, { halign = "center", scaling = true })
 		if menu.propertySorterType == "uix_extraSortByDistance_player" then
@@ -8851,7 +8860,7 @@ function menu.createPropertyOwned(frame, instance)
 			else
 				buttonLabel = name
 			end
-			sorterColumn = 4
+			sorterColumn = 6
 			tableColumn = (sorterColumn - 1) * colSpanPerSorterColumn + 1
 			local button = row[tableColumn]:setColSpan(colSpanPerSorterColumn):createButton({ scaling = false, height = buttonheight }):setText(buttonLabel, { halign = "center", scaling = true })
 			if menu.propertySorterType == "uix_extraSortByDistance_object" then

--- a/ui/addons/ego_detailmonitor/menu_map.xpl
+++ b/ui/addons/ego_detailmonitor/menu_map.xpl
@@ -1530,8 +1530,8 @@ local config = {
 		{ text = ReadText(1001, 3245) },																																								-- Map
 		-- hexes
 		{ icon = "maplegend_hexagon_fog_01",		text = ReadText(10002, 606),	width = Helper.sidebarWidth,	height = Helper.sidebarWidth },														-- Unknown location
-		{ icon = "maplegend_hexagon_01",			text = ReadText(1001, 11689),	width = Helper.sidebarWidth,	height = Helper.sidebarWidth,	color = Color["icon_inactive"] },					-- Potential Resource
-		{ icon = "maplegend_hexagon_01",			text = ReadText(1001, 11690),	width = Helper.sidebarWidth,	height = Helper.sidebarWidth },														-- Detected Resource
+		{ icon = "maplegend_hexagon_01",			text = ReadText(1001, 11689),	width = Helper.sidebarWidth,	height = Helper.sidebarWidth,	color = Color["resource_map_default"] },					-- Potential Resource
+		{ icon = "maplegend_hexagon_02",			text = ReadText(1001, 11690),	width = Helper.sidebarWidth,	height = Helper.sidebarWidth,	color = Color["resource_map_default"] },														-- Detected Resource
 		-- highways, gates, etc
 		{ icon = "solid",							text = ReadText(1001, 9809),	width = Helper.sidebarWidth,	height = Helper.standardTextHeight / 2,	minRowHeight = Helper.sidebarWidth / 2 },	-- Jump Gate Connection
 		{ icon = "maplegend_hw_01",					text = ReadText(20001, 601),	width = Helper.sidebarWidth,	height = Helper.sidebarWidth / 2,	color = "superhighwaycolor" },					-- Superhighway
@@ -6115,6 +6115,7 @@ function menu.onShowMenu(state)
 	menu.infoTableWidth = math.max(menu.infoTableWidth, 400)
 	menu.infoTableOffsetX = menu.sideBarOffsetX + menu.sideBarWidth + Helper.minorPanelSpacing
 	menu.infoTableOffsetY = menu.sideBarOffsetY
+	menu.infoTable2OffsetY = menu.sideBarOffsetY
 
 	-- searchfield
 	menu.searchFieldData = {
@@ -8214,7 +8215,7 @@ function menu.createObjectList(frame, instance)
 			menu.selectedCols["objectlist"] = nil
 		end
 	else
-		menu.settoprow = ((not menu.settoprow) or (menu.settoprow == 0)) and ((menu.setrow and menu.setrow > 21) and (menu.setrow - 17) or 3) or menu.settoprow
+		menu.settoprow = ((not menu.settoprow) or (menu.settoprow == 0)) and ((menu.setrow and menu.setrow > 21) and (menu.setrow - 17) or 1) or menu.settoprow
 		objecttable:setTopRow(menu.settoprow)
 		local highlightborderrow = menu.sethighlightborderrow or menu.setrow
 		if menu.infoTable then
@@ -8679,7 +8680,7 @@ function menu.createPropertyOwned(frame, instance)
 			menu.selectedCols["propertyowned"] = nil
 		end
 	else
-		menu.settoprow = ((not menu.settoprow) or (menu.settoprow == 0)) and ((menu.setrow and menu.setrow > 21) and (menu.setrow - 17) or 3) or menu.settoprow
+		menu.settoprow = ((not menu.settoprow) or (menu.settoprow == 0)) and ((menu.setrow and menu.setrow > 21) and (menu.setrow - 17) or 1) or menu.settoprow
 		ftable:setTopRow(menu.settoprow)
 		local highlightborderrow = menu.sethighlightborderrow or menu.setrow
 		if menu.infoTable then
@@ -16059,7 +16060,7 @@ function menu.addCrewSection(mode, inputtable, inputobject, instance, infocrew, 
 				local maxselect = math.min(peoplecapacity, roletable.amount + infocrew.reassigned.roles[i].amount + infocrew.unassigned.total)
 				local start = math.min(maxselect, roletable.amount + infocrew.reassigned.roles[i].amount)
 				row[1]:setColSpan(7):createSliderCell({ height = config.mapRowHeight, start = start, minSelect = roletable.transferring, max = peoplecapacity, maxSelect = maxselect, readOnly = not isplayerowned or not roletable.canhire }):setText(ffi.string(roletable.name), { fontsize = config.mapFontSize })
-				sliderrows[slidercounter] = { ["row"] = row, ["col"] = 2, ["roleindex"] = i,["id"] = roletable.id, ["name"] = roletable.name, ["desc"] = roletable.desc, ["amount"] = roletable.amount, ["numtiers"] = roletable.numtiers, ["canhire"] = roletable.canhire, ["tiers"] = {} }
+				sliderrows[slidercounter] = { ["row"] = row, ["col"] = 1, ["roleindex"] = i,["id"] = roletable.id, ["name"] = roletable.name, ["desc"] = roletable.desc, ["amount"] = roletable.amount, ["numtiers"] = roletable.numtiers, ["canhire"] = roletable.canhire, ["tiers"] = {} }
 				titlerow[1].properties.helpOverlayHeight = titlerow[1].properties.helpOverlayHeight + row:getHeight() + Helper.borderSize
 				local numtiers = roletable.numtiers
 				for j, tiertable in ipairs(roletable.tiers) do
@@ -16076,7 +16077,7 @@ function menu.addCrewSection(mode, inputtable, inputobject, instance, infocrew, 
 						local maxselect = math.min(peoplecapacity, tiertable.amount + infocrew.reassigned.roles[i].tiers[j].amount)
 						local start = math.min(maxselect, tiertable.amount + infocrew.reassigned.roles[i].tiers[j].amount)
 						row[2]:setColSpan(6):createSliderCell({ height = config.mapRowHeight, start = start, minSelect = tiertable.transferring, max = peoplecapacity, maxSelect = maxselect, readOnly = not isplayerowned }):setText(ffi.string(tiertable.name), { fontsize = config.mapFontSize })
-						sliderrows[slidercounter].tiers[j] = { ["row"] = row, ["col"] = 3, ["roleindex"] = i, ["name"] = tiertable.name, ["skilllevel"] = tiertable.skilllevel, ["amount"] = tiertable.amount }
+						sliderrows[slidercounter].tiers[j] = { ["row"] = row, ["col"] = 2, ["roleindex"] = i, ["name"] = tiertable.name, ["skilllevel"] = tiertable.skilllevel, ["amount"] = tiertable.amount }
 						titlerow[1].properties.helpOverlayHeight = titlerow[1].properties.helpOverlayHeight + row:getHeight() + Helper.borderSize
 					end
 				end
@@ -20660,7 +20661,7 @@ function menu.createSearchField(frame, width, height, offsetx, offsety, refresh,
 	for i = 1, math.min(maxsearchtermsdisplayed, #menu.searchtext) do
 		local usedrow = rows[2]
 		local col = 5 + i
-		if col > 8 then
+		if col > 7 then
 			usedrow = rows[3]
 			col = col - 2
 		end
@@ -20689,7 +20690,7 @@ function menu.createSearchField(frame, width, height, offsetx, offsety, refresh,
 		for i = 1, math.min(maxsearchtermsdisplayed - #menu.searchtext, #warefilter) do
 			local usedrow = rows[2]
 			local col = 5 + i + #menu.searchtext
-			if col > 8 then
+			if col > 7 then
 				usedrow = rows[3]
 				col = col - 2
 			end

--- a/ui/addons/ego_detailmonitor/menu_map.xpl
+++ b/ui/addons/ego_detailmonitor/menu_map.xpl
@@ -1,4 +1,4 @@
-
+﻿
 -- section == gMain_map
 -- param == { 0, 0, showzone, focuscomponent [, history] [, mode, modeparam] [, showmultiverse] [, focusoffset] }
 
@@ -8872,6 +8872,16 @@ function menu.createPropertyOwned(frame, instance)
 		end
 		--kuertee end: extra sort by distance
 	end
+
+
+	-- kuertee start: callback
+	if menu.uix_callbacks ["createPropertyOwned_on_tabtable_end"] then
+		local result
+		for uix_id, uix_callback in pairs (menu.uix_callbacks ["createPropertyOwned_on_tabtable_end"]) do
+			uix_callback (numdisplayed, instance, tabtable, infoTableData)
+		end
+	end
+	-- kuertee end: callback
 
 	tabtable:setSelectedRow(menu.selectedRows.propertytabs or menu.selectedRows.infotable2 or 0)
 	tabtable:setSelectedCol(menu.selectedCols.propertytabs or Helper.currentTableCol[menu.infoTable2] or 0)

--- a/ui/addons/ego_detailmonitor/menu_map.xpl
+++ b/ui/addons/ego_detailmonitor/menu_map.xpl
@@ -6931,7 +6931,14 @@ function menu.createInfoFrame()
 				menu.createOrderQueue(menu.infoFrame, menu.infoMode.left, "left")
 			elseif menu.infoMode.left == "standingorders" then
 				menu.createStandingOrdersMenu(menu.infoFrame, "left")
+				-- start: InfoSubmenu Create Letf call-back
+			elseif menu.uix_callbacks ["info_sub_menu_create"] then
+				for uix_id, uix_callback in pairs (menu.uix_callbacks ["info_sub_menu_create"]) do
+					uix_callback (menu.infoFrame, "left")
+				end
+				-- end: InfoSubmenu Create Letf call-back
 			end
+
 		elseif menu.infoTableMode == "missionoffer" then
 			menu.infoFrame.properties.autoFrameHeightPadding = Helper.standardContainerOffset
 			menu.createMissionMode(menu.infoFrame)
@@ -10917,7 +10924,25 @@ end
 
 function menu.createOrdersMenuHeader(frame, frameborder, instance)
 	-- sync with tab table in menu.createOrderQueue()
-	local numcols = #config.infoCategories + 3
+	-- start: InfoSubmenu To Show call-back
+	local infoCategories = {}
+	for i, entry in ipairs(config.infoCategories) do
+		local shown = true
+		if menu.uix_callbacks ["info_sub_menu_to_show"] then
+			for uix_id, uix_callback in pairs (menu.uix_callbacks ["info_sub_menu_to_show"]) do
+				if  uix_callback (menu.infoSubmenuObject, entry.category) == false then
+					shown = false
+					break
+				end
+			end
+		end
+		if shown then
+			table.insert(infoCategories, entry)
+		end
+	end
+	-- local numcols = #config.infoCategories + 3
+	local numcols = #infoCategories + 3
+	-- end: InfoSubmenu To Show call-back
 	local orderHeaderTable
 	if instance == "left" then
 		menu.orderHeaderTable = frame:addTable(numcols, { tabOrder = 1, reserveScrollBar = false, frameborder = frameborder.id })
@@ -10928,7 +10953,10 @@ function menu.createOrdersMenuHeader(frame, frameborder, instance)
 	end
 
 	local count = 0
-	for i, entry in ipairs(config.infoCategories) do
+	-- start: InfoSubmenu To Show call-back
+	-- for i, entry in ipairs(config.infoCategories) do
+	for i, entry in ipairs(infoCategories) do
+	-- end: InfoSubmenu To Show call-back
 		if entry.empty then
 			count = count + 0.5
 		else
@@ -10943,7 +10971,10 @@ function menu.createOrdersMenuHeader(frame, frameborder, instance)
 	end
 
 	orderHeaderTable:setColWidth(1, menu.scrollIconSize + Helper.standardContainerOffset, false)
-	for i, entry in ipairs(config.infoCategories) do
+	-- start: InfoSubmenu To Show call-back
+	-- for i, entry in ipairs(config.infoCategories) do
+	for i, entry in ipairs(infoCategories) do
+		-- end: InfoSubmenu To Show call-back
 		if entry.empty then
 			orderHeaderTable:setColWidth(i + 1, sideBarWidth / 2, false)
 		else
@@ -10962,7 +10993,10 @@ function menu.createOrdersMenuHeader(frame, frameborder, instance)
 	local count = 1
 
 	Helper.setTabScrollLeftIcon(menu, menu.panelState[instance .. "menu"], row, 1, menu.scrollIconSize)
-	for _, entry in ipairs(config.infoCategories) do
+	-- start: InfoSubmenu To Show call-back
+	-- for _, entry in ipairs(config.infoCategories) do
+	for _, entry in ipairs(infoCategories) do
+		-- end: InfoSubmenu To Show call-back
 		if not entry.empty then
 			local bgcolor = Color["row_title_background"]
 			local color = Color["icon_normal"]
@@ -20886,6 +20920,12 @@ function menu.createInfoFrame2()
 			menu.createOrderQueue(menu.infoFrame2, menu.infoMode.right, "right")
 		elseif menu.infoMode.right == "standingorders" then
 			menu.createStandingOrdersMenu(menu.infoFrame2, "right")
+			-- start: InfoSubmenu Create Right call-back
+		elseif menu.uix_callbacks ["info_sub_menu_create"] then
+			for uix_id, uix_callback in pairs (menu.uix_callbacks ["info_sub_menu_create"]) do
+				uix_callback (menu.infoFrame, "right")
+			end
+			-- end: InfoSubmenu Create Right call-back
 		end
 	else
 		-- empty
@@ -30529,6 +30569,16 @@ function menu.isInfoModeValidFor(object, mode)
 			return true
 		end
 	else
+		-- start: InfoSubmenu IsValid call-back
+		if menu.uix_callbacks ["info_sub_menu_is_valid_for"] then
+			for uix_id, uix_callback in pairs (menu.uix_callbacks ["info_sub_menu_is_valid_for"]) do
+				if  uix_callback (object, mode) then
+					return true
+				end
+			end
+		end
+		-- end: InfoSubmenu IsValid call-back
+
 		local text = ""
 		for i, entry in ipairs(config.infoCategories) do
 			if not entry.empty then

--- a/ui/addons/ego_detailmonitor/menu_ship_configuration.xpl
+++ b/ui/addons/ego_detailmonitor/menu_ship_configuration.xpl
@@ -2575,16 +2575,20 @@ function menu.buttonClearCustomShipName()
 	menu.refreshMenu()
 end
 
-function menu.buttonCustomShipNameAppendShip(name)
-	if menu.customshipname == "" then
-		menu.customshipname = name
+function menu.helperSpaceAwareConcat(stringa,stringb)
+	if stringa == "" or stringb  == "" then
+		return stringa .. stringb
 	else
-		if utf8.sub(menu.customshipname, -1) ~= " " then
-			menu.customshipname = menu.customshipname .. " "
+		if utf8.sub(stringa, -1) ~= " " then
+			stringa = stringa .. " "
 		end
-		menu.customshipname = menu.customshipname .. name
+		return stringa .. stringb
 	end
+end
 
+function menu.buttonCustomShipNameAppendShip(name)
+	menu.customshipname = menu.helperSpaceAwareConcat(menu.customshipname,name)
+	menu.customshipname = utf8.sub(menu.customshipname, 0, Helper.standardEditBoxMaxTextLength)
 	if menu.customShipNameEditBox then
 		C.SetEditBoxText(menu.customShipNameEditBox.id, menu.customshipname)
 	end
@@ -2592,15 +2596,8 @@ function menu.buttonCustomShipNameAppendShip(name)
 end
 
 function menu.buttonCustomShipNameAppendLoadout()
-	if menu.customshipname == "" then
-		menu.customshipname = menu.loadoutName
-	else
-		if utf8.sub(menu.customshipname, -1) ~= " " then
-			menu.customshipname = menu.customshipname .. " "
-		end
-		menu.customshipname = menu.customshipname .. menu.loadoutName
-	end
-
+	menu.customshipname = menu.helperSpaceAwareConcat(menu.customshipname,menu.loadoutName)
+	menu.customshipname = utf8.sub(menu.customshipname, 0, Helper.standardEditBoxMaxTextLength)
 	if menu.customShipNameEditBox then
 		C.SetEditBoxText(menu.customShipNameEditBox.id, menu.customshipname)
 	end
@@ -4391,6 +4388,7 @@ function menu.getDataAndDisplay(upgradeplan, crew, newedit, firsttime, noundo, s
 			menu.slotStats[upgradetype.type] = {}
 			slots.count = #slots
 			local sizecounts = {}
+			local mergedslotnumber
 			for i, slot in ipairs(slots) do
 				if menu.upgradewares[type] then
 					for _, upgradeware in ipairs(menu.upgradewares[type]) do
@@ -4415,12 +4413,24 @@ function menu.getDataAndDisplay(upgradeplan, crew, newedit, firsttime, noundo, s
 					slot.slotname = i
 					slot.slotsize = slotsize
 					if slot.slotsize ~= "" then
-						if sizecounts[slot.slotsize] then
-							sizecounts[slot.slotsize] = sizecounts[slot.slotsize] + 1
-						else
-							sizecounts[slot.slotsize] = 1
+						local countslot = true
+						if slots.mergedslotindices and slots.mergedslotindices[i] and mergedslotnumber then
+							countslot = false
 						end
-						slot.slotname = upgradetype.shorttext[slot.slotsize] .. sizecounts[slot.slotsize]
+
+						if countslot then
+							if sizecounts[slot.slotsize] then
+								sizecounts[slot.slotsize] = sizecounts[slot.slotsize] + 1
+							else
+								sizecounts[slot.slotsize] = 1
+							end
+							if slots.mergedslotindices and slots.mergedslotindices[i] and (not mergedslotnumber) then
+								mergedslotnumber = sizecounts[slot.slotsize]
+							end
+							slot.slotname = upgradetype.shorttext[slot.slotsize] .. sizecounts[slot.slotsize]
+						else
+							slot.slotname = upgradetype.shorttext[slot.slotsize] .. mergedslotnumber
+						end
 					end
 
 					menu.slotStats[upgradetype.type][slotsize] = (menu.slotStats[upgradetype.type][slotsize] or 0) + 1
@@ -5490,8 +5500,8 @@ function menu.displaySlots(frame, firsttime)
 
 		menu.equipmentOffsetY = ftable:getFullHeight() + Helper.borderSize
 
+		menu.equipmentMacroData = {}
 		if next(menu.groupedupgrades) then
-			menu.equipmentMacroData = {}
 			if (menu.upgradetypeMode == "enginegroup") or (menu.upgradetypeMode == "turretgroup") then
 				for i, upgradetype2 in ipairs(Helper.upgradetypes) do
 					if upgradetype2.supertype == "group" then
@@ -8402,11 +8412,13 @@ function menu.displayPlan(frame)
 			end
 
 			local row = ftable:addRow(true, {  })
-			row[1]:setColSpan(colspan + 1):createButton({ height = Helper.standardTextHeight, active = function () return not utf8.find(menu.customshipname, name, nil, true) end }):setText(ReadText(1001, 8588), { halign = "center" })
+			-- The "- 1" in the below line accounts for the " " added by helperSpaceAwareConcat
+			row[1]:setColSpan(colspan + 1):createButton({ height = Helper.standardTextHeight, active = function () return (not utf8.find(menu.customshipname, name, nil, true)) and (utf8.len(menu.customshipname) < (Helper.standardEditBoxMaxTextLength - 1)) end }):setText(ReadText(1001, 8588), { halign = "center" })
 			row[1].handlers.onClick = function () return menu.buttonCustomShipNameAppendShip(name) end
 
 			local row = ftable:addRow(true, {  })
-			row[1]:setColSpan(colspan + 1):createButton({ height = Helper.standardTextHeight, active = function () return not utf8.find(menu.customshipname, menu.loadoutName, nil, true) end }):setText(ReadText(1001, 8589), { halign = "center" })
+			-- The "- 1" in the below line accounts for the " " added by helperSpaceAwareConcat
+			row[1]:setColSpan(colspan + 1):createButton({ height = Helper.standardTextHeight, active = function () return (not utf8.find(menu.customshipname, menu.loadoutName, nil, true)) and (utf8.len(menu.customshipname) < (Helper.standardEditBoxMaxTextLength - 1)) end }):setText(ReadText(1001, 8589), { halign = "center" })
 			row[1].handlers.onClick = menu.buttonCustomShipNameAppendLoadout
 
 			local row = ftable:addRow(false, { bgColor = Color["row_background_unselectable"] })
@@ -9126,19 +9138,31 @@ function menu.displayStats(frame)
 			row[5]:setColSpan(2):createText((maxtraveldrivestabilityvalue < defaultmaxtraveldrivestabilityvalue) and ReadText(1001, 7736) or ReadText(1001, 7738), { halign = "right" })
 		end
 
-		if (shieldcapacitymodifier ~= 1) and (shieldrechargedelaymodifier ~= 1) and (shieldrechargeratemodifier ~= 1) then
-			local row = ftable:addRow(nil, {  })
-			if shieldcapacitymodifier ~= 1 then
-				row[1]:createText(ReadText(1001, 8599))
-				row[2]:setColSpan(2):createText(menu.displayModifier(shieldcapacitymodifier), { halign = "right" })
-			elseif shieldrechargedelaymodifier ~= 1 then
-				row[1]:createText(ReadText(1001, 13201))
-				row[2]:setColSpan(2):createText(menu.displayModifier(shieldrechargedelaymodifier), { halign = "right" })
-			elseif shieldrechargeratemodifier ~= 1 then
-				row[1]:createText(ReadText(1001, 13202))
-				row[2]:setColSpan(2):createText(menu.displayModifier(shieldrechargeratemodifier), { halign = "right" })
+		local row
+		local newrow, coloffset = true, 0
+
+		local shieldprops = {
+			{ name = ReadText(1001, 8599),	value = shieldcapacitymodifier },
+			{ name = ReadText(1001, 13201),	value = shieldrechargedelaymodifier },
+			{ name = ReadText(1001, 13202),	value = shieldrechargeratemodifier },
+		}
+		for _, shieldprop in ipairs(shieldprops) do
+			if shieldprop.value ~= 1 and shieldprop.value ~= nil then
+				if newrow then
+					row = ftable:addRow(nil, {  })
+					newrow = false
+				end
+				row[1 + coloffset]:createText(shieldprop.name)
+				row[2 + coloffset]:setColSpan(2):createText(menu.displayModifier(shieldprop.value), { halign = "right" })
+				if coloffset > 0 then
+					newrow = true
+					coloffset = 0
+				else
+					coloffset = 3
+				end
 			end
 		end
+
 
 		titletable.properties.y = Helper.viewHeight - titletable:getFullHeight() - Helper.borderSize - ftable:getVisibleHeight() - menu.statsData.offsetY
 		ftable.properties.y = titletable.properties.y + ftable.properties.y
@@ -9194,7 +9218,7 @@ function menu.evaluateShipOptions()
 					end
 				end
 				-- end: alexandretk call-back
-				
+
 				-- start: cpsdo call-back (ship options: override shiptypename)
 				if menu.uix_callbacks["cpsdo_evaluateShipOptions_override_shiptypename"] then
 					local shiptypename_override

--- a/ui/addons/ego_detailmonitor/menu_station_configuration.xpl
+++ b/ui/addons/ego_detailmonitor/menu_station_configuration.xpl
@@ -676,6 +676,7 @@ function menu.buttonLeftBar(mode, row)
 		PlaySound("ui_positive_select")
 		menu.modulesMode = mode
 	end
+	menu.noupdate = false
 	menu.refresh = menu.refresh or getElapsedTime()
 end
 
@@ -2182,6 +2183,7 @@ function menu.createTitleBar(frame)
 		table.sort(loadOptions, function (a, b) return a.text < b.text end)
 		row[2]:createDropDown(loadOptions, { textOverride = ReadText(1001, 7904), optionWidth = menu.titleData.dropdownWidth + 7 * (menu.titleData.height + Helper.borderSize) }):setTextProperties(config.dropDownTextProperties)
 		row[2].handlers.onDropDownActivated = function () menu.noupdate = true; menu.closeContextMenu() end
+		row[2].handlers.onDropDownDeactivated = function () menu.noupdate = false end
 		row[2].handlers.onDropDownConfirmed = menu.dropdownLoad
 		row[2].handlers.onDropDownRemoved = menu.dropdownRemovedCP
 		-- save
@@ -2264,7 +2266,7 @@ function menu.refreshTitleBar()
 		Helper.setCellContent(menu, menu.titlebartable, desc, 1, 1, nil, "editbox", nil, menu.editboxNameUpdateText)
 		-- dropdown
 		local desc = Helper.createDropDown(loadOptions, "", text, nil, true, true, 0, 0, 0, 0, nil, nil, "", menu.titleData.dropdownWidth + 7 * (menu.titleData.height + Helper.borderSize))
-		Helper.setCellContent(menu, menu.titlebartable, desc, 1, 2, nil, "dropdown", nil, function () menu.noupdate = true; menu.closeContextMenu() end, menu.dropdownLoad, menu.dropdownRemovedCP)
+		Helper.setCellContent(menu, menu.titlebartable, desc, 1, 2, nil, "dropdown", nil, function () menu.noupdate = true; menu.closeContextMenu() end, menu.dropdownLoad, menu.dropdownRemovedCP, function () menu.update = false end)
 		-- save
 		local desc = Helper.createButton(nil, Helper.createButtonIcon("menu_save", nil, 255, 255, 255, 100), true, true, 0, 0, 0, menu.titleData.height, nil, nil, nil, ReadText(1026, 7901))
 		Helper.setCellContent(menu, menu.titlebartable, desc, 1, 3, nil, "button", nil, menu.buttonTitleSave)

--- a/ui/addons/ego_detailmonitorhelper/helper.xpl
+++ b/ui/addons/ego_detailmonitorhelper/helper.xpl
@@ -529,6 +529,7 @@ Helper = {
 	standardTextOffsety = 0,
 	standardTextHeight = 16,
 	standardTextWidth = 0,
+	standardEditBoxMaxTextLength = 50,
 	-- title text properties
 	titleFont = "Zekton bold",
 	titleFontSize = 12,
@@ -1344,6 +1345,11 @@ local function createCustomHooks(menu)
 								menu.onDropDownActivated(dropdown)
 							end
 						end
+	menu.dropdownDeactivated = function(dropdown)
+							if menu.onDropDownDeactivated then
+								menu.onDropDownDeactivated(dropdown)
+							end
+						end
 	menu.dropdownConfirmed = function(dropdown, value)
 							PlaySound("ui_positive_click")
 							if menu.onDropDownConfirmed then
@@ -1787,7 +1793,9 @@ function Helper.openInteractMenu(menu, param)
 	Helper.interactMenuCallbacks.onTableMouseOver = menu.onTableMouseOver
 
 	Helper.interactMenuActive = true
-	menu.updateInputBar()
+	if menu.updateInputBar then
+		menu.updateInputBar()
+	end
 	Helper.updateHandlerBackup = onUpdateHandler
 	local nextUpdateTime = 0
 	onUpdateHandler = function()
@@ -2831,12 +2839,15 @@ function Helper.setCheckBoxScript(menu, id, tableobj, row, col, script)
 	SetScript(cell, "onCheckBoxSelect", menu.checkboxOver)
 end
 
-function Helper.setDropDownScript(menu, id, tableobj, row, col, activateScript, confirmScript, removedScript)
+function Helper.setDropDownScript(menu, id, tableobj, row, col, activateScript, confirmScript, removedScript, deactivateScript)
 	menu.dropdownScriptMap = menu.dropdownScriptMap or {}
 	local layer = Helper.findFrameLayer(menu, tableobj)
 
 	if not activateScript then
 		activateScript = menu.dropdownActivated
+	end
+	if not deactivateScript then
+		deactivateScript = menu.dropdownDeactivated
 	end
 	if not confirmScript then
 		confirmScript = menu.dropdownConfirmed
@@ -2865,12 +2876,14 @@ function Helper.setDropDownScript(menu, id, tableobj, row, col, activateScript, 
 	end
 
 	table.insert(menu.dropdownScriptMap, { layer = layer, tableobj = tableobj, row = row, col = col, type = "onDropDownActivated", script = activateWrapper })
+	table.insert(menu.dropdownScriptMap, { layer = layer, tableobj = tableobj, row = row, col = col, type = "onDropDownDeactivated", script = deactivateScript })
 	table.insert(menu.dropdownScriptMap, { layer = layer, tableobj = tableobj, row = row, col = col, type = "onDropDownConfirmed", script = scriptWrapper })
 	table.insert(menu.dropdownScriptMap, { layer = layer, tableobj = tableobj, row = row, col = col, type = "onDropDownRemoved", script = removedScript })
 	table.insert(menu.dropdownScriptMap, { layer = layer, tableobj = tableobj, row = row, col = col, type = "onDropDownOptionChanged", script = onOptionChangedScript })
 
 	local cell = GetCellContent(tableobj, row, col)
 	SetScript(cell, "onDropDownActivated", activateWrapper)
+	SetScript(cell, "onDropDownDeactivated", deactivateScript)
 	SetScript(cell, "onDropDownConfirmed", scriptWrapper)
 	SetScript(cell, "onDropDownRemoved", removedScript)
 	SetScript(cell, "onDropDownOptionChanged", onOptionChangedScript)
@@ -3339,7 +3352,7 @@ local defaultWidgetProperties = {
 		selectTextOnActivation = true,							-- whether the text is pre-selected when activating the editbox
 		active = true,											-- whether the editbox is active
 		restoreInteractiveObject = false,						-- whether the input focus is restored to the previous object after the editbox is deactivated
-		maxChars = 50,											-- max characters that can be entered
+		maxChars = Helper.standardEditBoxMaxTextLength,			-- max characters that can be entered
 		_basetype = "cell"
 	},
 	["shieldhullbar"] = {
@@ -4265,7 +4278,7 @@ function onFrameHandleViewCreated(framehandle, frames)
 							elseif cell.type == "slidercell" then
 								Helper.setSliderCellScript(menu, triggerid, widgetid, rowidx, cellidx, cell.handlers.onSliderCellChanged, cell.handlers.onSliderCellActivated, cell.handlers.onSliderCellDeactivated, cell.handlers.onRightClick, cell.handlers.onSliderCellConfirm)
 							elseif cell.type == "dropdown" then
-								Helper.setDropDownScript(menu, triggerid, widgetid, rowidx, cellidx, cell.handlers.onDropDownActivated, cell.handlers.onDropDownConfirmed, cell.handlers.onDropDownRemoved)
+								Helper.setDropDownScript(menu, triggerid, widgetid, rowidx, cellidx, cell.handlers.onDropDownActivated, cell.handlers.onDropDownConfirmed, cell.handlers.onDropDownRemoved, cell.handlers.onDropDownDeactivated)
 							elseif cell.type == "graph" then
 								Helper.setGraphScript(menu, triggerid, widgetid, rowidx, cellidx, cell.handlers.onClick)
 							end

--- a/ui/addons/ego_gameoptions/customgame.xpl
+++ b/ui/addons/ego_gameoptions/customgame.xpl
@@ -189,7 +189,7 @@ ffi.cdef[[
 		const char* macro;
 		int amount;
 	} UIWareInfo;
-	
+
 	typedef struct {
 		const char* type;
 		const char* id;
@@ -1176,11 +1176,11 @@ function menu.addSatellite(sector, id, x, z)
 	local entryid = ffi.string(C.SetCustomGameStartPlayerPropertyObjectMacro(menu.customgamestart, "playerproperty", id, config.satellites.macro))
 	if entryid ~= "" then
 		local sectorpos = ffi.new("UIPosRot", {
-			x = x, 
-			y = 0, 
-			z = z, 
-			yaw = 0, 
-			pitch = 0, 
+			x = x,
+			y = 0,
+			z = z,
+			yaw = 0,
+			pitch = 0,
 			roll = 0
 		})
 		C.SetCustomGameStartPlayerPropertySectorAndOffset(menu.customgamestart, "playerproperty", entryid, sector, sectorpos)
@@ -1314,11 +1314,11 @@ function menu.addHQ()
 
 			local sector = "cluster_01_sector001_macro"
 			local sectorpos = ffi.new("UIPosRot", {
-				x = 128000, 
-				y = 0, 
-				z = 198000, 
-				yaw = 0, 
-				pitch = 0, 
+				x = 128000,
+				y = 0,
+				z = 198000,
+				yaw = 0,
+				pitch = 0,
 				roll = 0
 			})
 			C.SetCustomGameStartPlayerPropertySectorAndOffset(menu.customgamestart, "playerproperty", entryid, sector, sectorpos)
@@ -1443,7 +1443,7 @@ function menu.dropdownImport(filename)
 	end
 
 	C.ImportCustomGameStart(menu.customgamestart, filename, menu.customgamestart)
-	
+
 	menu.initEncyclopediaValue()
 	menu.initKnownValue()
 	menu.initStoryValue()
@@ -2004,7 +2004,7 @@ function menu.universeSector(current)
 		if not hidden then
 			local mouseovertext = ""
 			local active = true
-			
+
 			if not unlocked then
 				active = false
 				mouseovertext = ReadText(1026, 9928)
@@ -2450,7 +2450,7 @@ function menu.displayMultiSelection(property)
 						end
 					end
 				end
-				
+
 				if active then
 					if menu.contextMenuData.propertyLockedWares[entry.id] then
 						active = false
@@ -2957,6 +2957,7 @@ function menu.display()
 			local filename = ffi.string(buf[i].filename)
 			local name = ffi.string(buf[i].name)
 			local active = true
+			local hasdeprecatedwares = false
 			local mouseovertext = ""
 
 			local content = C.GetCustomGameStartContentCounts2(menu.customgamestart, filename, menu.customgamestart)
@@ -2986,10 +2987,13 @@ function menu.display()
 						nocustomgamestart = false
 						islimited = false
 					end
-					if (not hasblueprint) or isdeprecated or (not isplayerblueprintallowed) or nocustomgamestart then
+					if (not hasblueprint) or (not isplayerblueprintallowed) or nocustomgamestart then
 						active = false
 						mouseovertext = ReadText(1026, 9925)
 						break
+					end
+					if isdeprecated then
+						hasdeprecatedwares = true
 					end
 					if islimited then
 						usedlimitedwares[ware] = (usedlimitedwares[ware] or 0) + buf_content.macros[j].amount
@@ -3021,10 +3025,13 @@ function menu.display()
 							break
 						end
 					end
-					if (not hasblueprint) or isdeprecated or (not isplayerblueprintallowed) or nocustomgamestart or isventure or ismissiononly then
+					if (not hasblueprint) or (not isplayerblueprintallowed) or nocustomgamestart or isventure or ismissiononly then
 						active = false
 						mouseovertext = ReadText(1026, 9926)
 						break
+					end
+					if isdeprecated then
+						hasdeprecatedwares = true
 					end
 				end
 			end
@@ -3040,6 +3047,10 @@ function menu.display()
 						break
 					end
 				end
+			end
+
+			if active and hasdeprecatedwares then
+				mouseovertext = mouseovertext .. ((mouseovertext ~= "") and "\n\n" or "") .. ColorText["text_warning"] .. ReadText(1026, 9932)
 			end
 
 			table.insert(menu.availablecustomgamestarts, { id = filename, text = name, icon = "", displayremoveoption = false, active = active, mouseovertext = mouseovertext })
@@ -3307,7 +3318,7 @@ function menu.display()
 							if i ~= 1 then
 								row = menu.propertyTable:addRow(property, {  })
 							end
-							
+
 							if property.id == "playerknownspace" then
 								row[3]:setColSpan(1):createButton({ helpOverlayID = "knownsector_expand", helpOverlayText = " ", helpOverlayHighlightOnly = true }):setText(menu.expandedProperty["knownsector_" .. entry.id] and "-" or "+", { halign = "center", x = 0 })
 								row[3].handlers.onClick = function () return menu.buttonExpandProperty("knownsector_" .. entry.id) end
@@ -5316,7 +5327,7 @@ function menu.onUpdate()
 										if cutscenekey then
 											menu.cutscenedesc = CreateCutsceneDescriptor(cutscenekey, { npcref = menu.prenpc })
 											menu.cutsceneid = StartCutscene(menu.cutscenedesc, rendertargetTexture)
-											
+
 											if not menu.cutsceneNotification then
 												NotifyOnCutsceneReady(getElement("Scene.UIContract"))
 												NotifyOnCutsceneStopped(getElement("Scene.UIContract"))
@@ -5438,7 +5449,7 @@ end
 -- rendertarget mouse input helper
 function menu.onRenderTargetMouseDown(modified)
 	menu.leftdown = { time = getElapsedTime(), position = table.pack(GetLocalMousePosition()), dynpos = table.pack(GetLocalMousePosition()) }
-	
+
 	if menu.holomap ~= 0 then
 		C.StartPanMap(menu.holomap)
 		menu.panningmap = { isclick = true }
@@ -5479,7 +5490,7 @@ function menu.onRenderTargetRightMouseUp(modified)
 		if menu.holomap ~= 0 then
 			local sectorpos = ffi.new("UIPosRot")
 			local sectormacro = ffi.string(C.GetMacroMapPositionOnEcliptic(menu.holomap, sectorpos))
-		
+
 			if menu.category.id == "universe" then
 				if sectormacro ~= "" then
 					menu.displayMapContext(offset, sectormacro, sectorpos)

--- a/ui/addons/ego_gameoptions/gameoptions.xpl
+++ b/ui/addons/ego_gameoptions/gameoptions.xpl
@@ -1308,19 +1308,18 @@ config.optionDefinitions = {
 			submenu = "tutorials",
 		},
 		[7] = {
-			id = "timelines",
-			name = ReadText(1001, 12661),
-			prefixicon = function () return menu.prefixIconTopLevel("timelines") end,
-			mouseOverText = ReadText(1026, 2696) .. "\n\n" .. ReadText(1026, 2681),
-			submenu = "timelines",
-			selectable = function () return ffi.string(C.GetGameStartName()) ~= "x4ep1_gamestart_hub" end,
-		},
-		[8] = {
 			id = "new",
-			name = ReadText(1001, 12662),
+			name = ReadText(1001, 12790),
 			prefixicon = function () return menu.prefixIconTopLevel("new") end,
 			submenu = "new",
 			mouseOverText = ReadText(1026, 4801) .. "\n\n" .. ReadText(1026, 4802),
+		},
+		[8] = {
+			id = "timelines",
+			name = ReadText(1001, 12661),
+			mouseOverText = ReadText(1026, 2696),
+			submenu = "timelines",
+			selectable = function () return ffi.string(C.GetGameStartName()) ~= "x4ep1_gamestart_hub" end,
 		},
 		[9] = {
 			id = "multiplayer",
@@ -4304,22 +4303,16 @@ end
 function menu.createContextMenuFirstGame(frame)
 	local ftable = frame:addTable(3, { tabOrder = 1, width = menu.contextMenuData.width, x = 3 * Helper.borderSize, y = 3 * Helper.borderSize, defaultInteractiveObject = true })
 
-	local hastimelines = C.HasExtension("ego_dlc_timelines", false)
+	local row = ftable:addRow(false, { fixed = true })
+	row[1]:setColSpan(3):createText(ReadText(1001, 12720), Helper.headerRowCenteredProperties)
 
 	local row = ftable:addRow(false, { fixed = true })
-	row[1]:setColSpan(3):createText(hastimelines and ReadText(1001, 12716) or ReadText(1001, 12720), Helper.headerRowCenteredProperties)
-
-	local row = ftable:addRow(false, { fixed = true })
-	if hastimelines then
-		row[1]:setColSpan(3):createText(ReadText(1001, 12717) .. "\n\n" .. ReadText(1001, 12718) .. " " .. ReadText(1001, 12722) .. "\n\n" .. ReadText(1001, 12719), { wordwrap = true })
-	else
-		row[1]:setColSpan(3):createText(ReadText(1001, 12721) .. "\n\n" .. ReadText(1001, 12722) .. "\n\n" .. ReadText(1001, 12719), { wordwrap = true })
-	end
+	row[1]:setColSpan(3):createText(ReadText(1001, 12789) .. "\n\n" .. ReadText(1001, 12722), { wordwrap = true })
 
 	ftable:addEmptyRow()
 
 	local row = ftable:addRow(true, { fixed = true })
-	row[2]:createButton({  }):setText(ReadText(1001, 14), { halign = "center" })
+	row[2]:createButton({  }):setText("\27[menu_recommended] " .. ReadText(1001, 14), { halign = "center" })
 	row[2].handlers.onClick = function() menu.closeContextMenu() end
 
 	return ftable:getVisibleHeight()
@@ -6180,18 +6173,9 @@ function menu.nameOnlineSeason()
 end
 
 function menu.prefixIconTopLevel(type)
-	local m0bossscore = ffi.string(C.GetUserData("scenario_m0_boss_battle_best_score"))
-	local timelinesDone = false
-	if m0bossscore ~= "" then
-		timelinesDone = tonumber(m0bossscore) >= 1
-	end
-	local hastimelines = C.HasExtension("ego_dlc_timelines", false)
-
 	if (type == "tutorials") and (not menu.allBasicTutorialsDone) then
 		return "menu_recommended", Color["gamestart_recommended"]
-	elseif (type == "timelines") and menu.allBasicTutorialsDone and hastimelines and (not timelinesDone) then
-		return "menu_recommended", Color["gamestart_recommended"]
-	elseif(type == "new") and menu.allBasicTutorialsDone and (timelinesDone or (not hastimelines)) then
+	elseif(type == "new") and menu.allBasicTutorialsDone then
 		return "menu_recommended", Color["gamestart_recommended"]
 	end
 end


### PR DESCRIPTION
  function menu.createInfoFrame(): +added callback for creating left info submenu
  function menu.createOrdersMenuHeader(frame, frameborder, instance): +added callback for showing info submenu
  function menu.createInfoFrame2(): +added callback for creating right info submenu
  function menu.isInfoModeValidFor(object, mode): +added validation callback for info submenu