### PR TITLE
Post 9.0 beta 3. Fix(menu_map): correct info frame callback for right submenu

### DIFF
--- a/ui/addons/ego_detailmonitor/menu_map.xpl
+++ b/ui/addons/ego_detailmonitor/menu_map.xpl
@@ -20923,7 +20923,7 @@ function menu.createInfoFrame2()
 			-- start: InfoSubmenu Create Right call-back
 		elseif menu.uix_callbacks ["info_sub_menu_create"] then
 			for uix_id, uix_callback in pairs (menu.uix_callbacks ["info_sub_menu_create"]) do
-				uix_callback (menu.infoFrame, "right")
+				uix_callback (menu.infoFrame2, "right")
 			end
 			-- end: InfoSubmenu Create Right call-back
 		end


### PR DESCRIPTION
  function menu.createInfoFrame2(): ~modified callback to use infoFrame2 instead of infoFrame (ensures correct frame is updated)