### PR TITLE
fix(gameoptions): improve author display logic for extensions

### DIFF
--- a/ui/addons/ego_gameoptions/gameoptions.xpl
+++ b/ui/addons/ego_gameoptions/gameoptions.xpl
@@ -2984,8 +2984,8 @@ function menu.loadSaveCallback(_, filename)
 			if menu.uix_callbacks ["loadGameCallback_preLoadGame"] then
 				for uix_id, uix_callback in pairs (menu.uix_callbacks ["loadGameCallback_preLoadGame"]) do
 					uix_callback(filename)
-		end
-	end
+				end
+			end
 			LoadGame(filename)
 		end
 		, true, getElapsedTime() + 0.1)

--- a/ui/addons/ego_gameoptions/gameoptions.xpl
+++ b/ui/addons/ego_gameoptions/gameoptions.xpl
@@ -2984,8 +2984,8 @@ function menu.loadSaveCallback(_, filename)
 			if menu.uix_callbacks ["loadGameCallback_preLoadGame"] then
 				for uix_id, uix_callback in pairs (menu.uix_callbacks ["loadGameCallback_preLoadGame"]) do
 					uix_callback(filename)
-				end
-			end
+		end
+	end
 			LoadGame(filename)
 		end
 		, true, getElapsedTime() + 0.1)
@@ -10602,7 +10602,7 @@ function menu.displayExtensions()
 				end
 				-- add name of author
 				local row = optiontable:addRow(false, {})
-				row[2]:createText(extension.author, config.standardTextProperties)
+				row[2]:setColSpan(6):createText(extension.author, config.standardTextProperties)
 				row[2].properties.fontsize = row[2].properties.fontsize * 2
 				if not extension.enabled then
 					row[2].properties.color = Helper.color.grey
@@ -10904,7 +10904,11 @@ function menu.displayModRow(ftable, extension, extensionSetting)
 	row[2]:createText(extension.name, config.standardTextProperties)
 	row[2].properties.color = textcolor
 
-	row[3]:createText(extension.id, config.standardTextProperties)
+	local textIdAuthor = extension.id
+	if not (__userdata_uix_gameoptions.modsortertype =="author" or __userdata_uix_gameoptions.modsortertype == "authorinverse") and extension.author ~= "" then
+		textIdAuthor = extension.author .. "\n" .. extension.id
+	end
+	row[3]:createText(textIdAuthor, config.standardTextProperties)
 
 	row[4]:createText(extension.version, config.standardTextProperties)
 	row[4].properties.halign = "right"


### PR DESCRIPTION
  function menu.displayExtensions(): ~set column span for author text (improves layout)
  function menu.displayModRow(ftable, extension, extensionSetting): ~combine author and ID display logic (enhances clarity)