### PR TITLE
Two fixes related to the object distance sorter

### DIFF
--- a/ui/addons/ego_detailmonitor/menu_map.xpl
+++ b/ui/addons/ego_detailmonitor/menu_map.xpl
@@ -19105,7 +19105,7 @@ function menu.createMissionMode(frame)
 			-- kuertee end
 
 				local othermissionrowgroup = ftable:addRowGroup({  })
-	
+
 				for _, entry in ipairs(menu.missionOfferList["other"]) do
 					found = true
 					menu.addMissionRow(ftable, othermissionrowgroup, entry)
@@ -32354,6 +32354,9 @@ function menu.addSelectedComponent(component, clear, noupdate)
 	if not next(menu.selectedcomponents) and add then
 		-- always set uix_extraSortByDistance_byObject_potentialObject to only the first component added to menu.selectedcomponents
 		uix_extraSortByDistance_byObject_potentialObject = component
+	else
+		local firstSelectedComponent = next(menu.selectedcomponents)
+		uix_extraSortByDistance_byObject_potentialObject = firstSelectedComponent and ConvertStringTo64Bit(tostring(firstSelectedComponent)) or nil
 	end
 	-- kuertee end: extra sort by distance
 
@@ -32573,7 +32576,7 @@ function menu.setFilterOption(mode, setting, id, value, index)
 	if not settings[mode] then
 		settings[mode] = true
 		menu.applyFilterSettings(nil, true)
-	else 
+	else
 		setting.callback(setting, nil, nil, true)
 	end
 end

--- a/ui/addons/ego_detailmonitor/menu_map.xpl
+++ b/ui/addons/ego_detailmonitor/menu_map.xpl
@@ -32256,7 +32256,7 @@ function menu.updateTableSelection(lastcomponent)
 		end
 
 		-- kuertee start: extra sort by distance
-		if (not refresh) and (menu.infoTableMode == "propertyowned" or menu.infoTableMode == "objectlist") and (not uix_extraSortByDistance_byObject_mode) then
+		if (not refresh) and (menu.infoTableMode == "propertyowned"--[[  or menu.infoTableMode == "objectlist" ]]) and (not uix_extraSortByDistance_byObject_mode) then
 			if uix_extraSortByDistance_byObject_object ~= uix_extraSortByDistance_byObject_potentialObject then
 				refresh = true
 			end


### PR DESCRIPTION
Two fixes related to the object distance sorter:

- Prevent to set uix_extraSortByDistance_byObject_potentialObject to nil if menu.selectedcomponents is not empty
- Disable refresh for setting up the Distance Sorter button on changing the uix_extraSortByDistance_byObject_potentialObject for objectlist mode, as uix_renderExtraSortByDistance not enabled. To prevent extra refresh (due to for objectlist the uix_extraSortByDistance_byObject_object never be equal to uix_extraSortByDistance_byObject_potentialObject, as uix_renderExtraSortByDistance disabled)