### PR TITLE
Add context menu close intercept and custom interact type callbacks

### DIFF
--- a/ui/addons/ego_detailmonitor/menu_map.xpl
+++ b/ui/addons/ego_detailmonitor/menu_map.xpl
@@ -31860,6 +31860,16 @@ function menu.getParamValue(type, value, inputparams)
 end
 
 function menu.closeContextMenu(dueToClose, keepmenu)
+	-- kuertee start: callback
+	if menu.uix_callbacks["closeContextMenu_on_before"] then
+		for uix_id, uix_callback in pairs(menu.uix_callbacks["closeContextMenu_on_before"]) do
+			if uix_callback(dueToClose, keepmenu) then
+				return true
+			end
+		end
+	end
+	-- kuertee end: callback
+
 	AddUITriggeredEvent(menu.name, "contextmenu_close")
 
 	if Helper.closeInteractMenu() then
@@ -32251,6 +32261,17 @@ function menu.onInteractMenuCallback(type, param)
 	elseif type == "uix_centeronmap" then
 		menu.uix_centerOnMap(param[1], param[2])
 	-- kuertee end: center on map
+
+	-- kuertee start: callback
+	else
+		if menu.uix_callbacks["onInteractMenuCallback_on_custom_type"] then
+			for uix_id, uix_callback in pairs(menu.uix_callbacks["onInteractMenuCallback_on_custom_type"]) do
+				if uix_callback(type, param) then
+					return
+				end
+			end
+		end
+	-- kuertee end: callback
 	end
 end
 


### PR DESCRIPTION
Added 'closeContextMenu_on_before' callback in Map Menu to allow mods to intercept context menu closure. Returns true to prevent closing.

Added 'onInteractMenuCallback_on_custom_type' callback to handle custom interact menu types via registered callbacks. Returns true to consume the event.