### PR TITLE
8.0:  fix to prevent duplicate root section promotions (with substs and readme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Contributors: AlexandreTK, ChemODun, Damonya, DrWhoKnows, DmytroK, Erixon, Farem
 
 Updates
 =======
-v8.0.4.7, 23 June 2026:
+v8.0.4.7, 25 June 2026:
 - New callbacks: in gameoptions for the controls management by ChemODun.
+- Fix:  For hierarchical sub-groups in the Interact Menu, to prevent double addition of sub-groups.
 
 NOTES FOR PLAYERS:
 ==================

--- a/subst_01.cat
+++ b/subst_01.cat
@@ -17,4 +17,4 @@ ui/addons/ego_detailmonitor/menu_userquestion.xpl 27453 1782219465 f6ac6aaadbb40
 ui/addons/ego_detailmonitorhelper/helper.xpl 539328 1782219465 b6425f47c17fc5044e0e2fd415a01ed7
 ui/addons/ego_gameoptions/customgame.xpl 238460 1782219465 a8943b33ef87f68a2e6cd0594b78cb92
 ui/addons/ego_gameoptions/gameoptions.xpl 571858 1782219465 84feb2d63c071b3a31ac22d91ad8ccd1
-ui/addons/ego_interactmenu/menu_interactmenu.xpl 392549 1782219465 604dc4c632349143322899e50777b40f
+ui/addons/ego_interactmenu/menu_interactmenu.xpl 393148 1782398398 47de9432762454915ca8d19bcdcef7fe

--- a/ui/addons/ego_interactmenu/menu_interactmenu.xpl
+++ b/ui/addons/ego_interactmenu/menu_interactmenu.xpl
@@ -8053,6 +8053,12 @@ function menu.Add_Custom_Actions_Group_Text(_, text)
 end
 
 function menu.Add_Custom_Actions_Group(id, text)
+	-- chemodun start: skip re-adding a group that was already promoted to a root section
+	if menu.uix_convertedRootSectionIds[id] then
+		Helper.debugText("Add_Custom_Actions_Group: id already promoted to root, skipping: " .. tostring(id))
+		return
+	end
+	-- chemodun end: skip re-adding a group that was already promoted to a root section
 	local customActionsSection
 	local customActionsSection_isFound = false
 	local customActionsSection_isAddTo = string.find(id, "actions_")
@@ -8139,6 +8145,12 @@ function menu.Add_Custom_Actions_SubGroup(parentId, subGroupId, text)
 			if section.id == parentId then
 				if not section.subsections then
 					section.subsections = {}
+				end
+				for _, subsection in ipairs(section.subsections) do
+					if subsection.id == subGroupId then
+						Helper.debugText("Add_Custom_Actions_SubGroup: subGroupId already present in root section: " .. tostring(subGroupId))
+						return
+					end
 				end
 				table.insert(section.subsections, { id = subGroupId, text = text })
 				return


### PR DESCRIPTION
fix(ego_interactmenu): prevent duplicate root section promotions

  function menu.Add_Custom_Actions_Group(id, text): +skip re-adding if already promoted to root.
  function menu.Add_Custom_Actions_SubGroup(parentId, subGroupId, text): +skip adding if subGroupId already present in root section.