### PR TITLE
ship configuration: add equipment inventory callbacks

### DIFF
--- a/ui/addons/ego_detailmonitor/menu_ship_configuration.xpl
+++ b/ui/addons/ego_detailmonitor/menu_ship_configuration.xpl
@@ -4089,6 +4089,22 @@ function menu.getDataAndDisplay(upgradeplan, crew, newedit, firsttime, noundo, s
 		end
 	end
 
+	-- kuertee start: callback
+	if menu.uix_callbacks["getDataAndDisplay_on_assemble_possible_upgrades"] then
+		for uix_id, uix_callback in pairs(menu.uix_callbacks["getDataAndDisplay_on_assemble_possible_upgrades"]) do
+			local callbackresult = uix_callback({
+				upgradewares = menu.upgradewares,
+				mode = menu.mode,
+				object = menu.object,
+				macro = menu.macro,
+				isreadonly = menu.isReadOnly,
+			})
+			if callbackresult and callbackresult.upgradewares then
+				menu.upgradewares = callbackresult.upgradewares
+			end
+		end
+	end
+	-- kuertee end: callback
 	-- sort
 	for _, upgradetype in ipairs(Helper.upgradetypes) do
 		if upgradetype.supertype ~= "group" then
@@ -5699,6 +5715,31 @@ function menu.displaySlots(frame, firsttime)
 
 											local active = ((group[i].macro == plandata.macro) or (not hasmod))
 											local useable = hasstock and haslicence
+											local onclick
+											-- kuertee start: callback
+											if menu.uix_callbacks["displaySlots_on_create_upgrade_button"] then
+												for uix_id, uix_callback in pairs(menu.uix_callbacks["displaySlots_on_create_upgrade_button"]) do
+													local callbackresult = uix_callback({
+														macro = group[i].macro,
+														plannedmacro = plandata.macro,
+														upgradetype = upgradetype2.type,
+														slot = menu.currentSlot,
+														grouped = true,
+														active = active,
+														useable = useable,
+														mouseovertext = mouseovertext,
+														extratext = extraText,
+													})
+													if callbackresult then
+														if callbackresult.active ~= nil then active = callbackresult.active end
+														if callbackresult.useable ~= nil then useable = callbackresult.useable end
+														if callbackresult.mouseovertext ~= nil then mouseovertext = callbackresult.mouseovertext end
+														if callbackresult.extratext ~= nil then extraText = callbackresult.extratext end
+														if callbackresult.onclick ~= nil then onclick = callbackresult.onclick end
+													end
+												end
+											end
+											-- kuertee end: callback
 											local overlayid
 											if group[i].macro == "" then
 												overlayid = "shipconfig_upgrade_empty"
@@ -5716,7 +5757,9 @@ function menu.displaySlots(frame, firsttime)
 												helpOverlayHighlightOnly = true,
 											}):setIcon(group[i].icon):setIcon2(installicon, { color = installcolor }):setText(icon, { y = maxColumnWidth / 2 - Helper.scaleY(Helper.standardTextHeight) / 2 - Helper.configButtonBorderSize, halign = "right", color = overridecolor, fontsize = Helper.scaleFont(Helper.standardFont, Helper.standardFontSize) }):setText2(weaponicon, { x = 3, y = -maxColumnWidth / 2 + Helper.scaleY(Helper.standardTextHeight) / 2 + Helper.configButtonBorderSize, fontsize = Helper.scaleFont(Helper.standardFont, Helper.standardFontSize) })
 											menu.equipmentMacroData[row.index * 1000 + column] = { macro = group[i].macro, hasmod = hasmod, price = price, type = upgradetype2.type }
-											if useable then
+											if onclick then
+												row[column].handlers.onClick = onclick
+											elseif useable then
 												row[column].handlers.onClick = function () return menu.buttonSelectGroupUpgrade(upgradetype2.type, menu.currentSlot, group[i].macro, row.index, column) end
 											end
 											if group[i].macro ~= "" then
@@ -5985,6 +6028,31 @@ function menu.displaySlots(frame, firsttime)
 
 							local active = ((group[i].macro == plandata.macro) or (not hasmod))
 							local useable = hasstock and haslicence
+							local onclick
+							-- kuertee start: callback
+							if menu.uix_callbacks["displaySlots_on_create_upgrade_button"] then
+								for uix_id, uix_callback in pairs(menu.uix_callbacks["displaySlots_on_create_upgrade_button"]) do
+									local callbackresult = uix_callback({
+										macro = group[i].macro,
+										plannedmacro = plandata.macro,
+										upgradetype = upgradetype.type,
+										slot = menu.currentSlot,
+										grouped = false,
+										active = active,
+										useable = useable,
+										mouseovertext = mouseovertext,
+										extratext = extraText,
+									})
+									if callbackresult then
+										if callbackresult.active ~= nil then active = callbackresult.active end
+										if callbackresult.useable ~= nil then useable = callbackresult.useable end
+										if callbackresult.mouseovertext ~= nil then mouseovertext = callbackresult.mouseovertext end
+										if callbackresult.extratext ~= nil then extraText = callbackresult.extratext end
+										if callbackresult.onclick ~= nil then onclick = callbackresult.onclick end
+									end
+								end
+							end
+							-- kuertee end: callback
 							local overlayid
 							if group[i].macro == "" then
 								overlayid = "shipconfig_upgrade_empty"
@@ -6002,7 +6070,9 @@ function menu.displaySlots(frame, firsttime)
 								helpOverlayHighlightOnly = true,
 							}):setIcon(group[i].icon):setIcon2(installicon, { color = installcolor }):setText(icon, { y = maxColumnWidth / 2 - Helper.scaleY(Helper.standardTextHeight) / 2 - Helper.configButtonBorderSize, halign = "right", color = overridecolor, fontsize = Helper.scaleFont(Helper.standardFont, Helper.standardFontSize) }):setText2(weaponicon, { x = 3, y = -maxColumnWidth / 2 + Helper.scaleY(Helper.standardTextHeight) / 2 + Helper.configButtonBorderSize, fontsize = Helper.scaleFont(Helper.standardFont, Helper.standardFontSize) })
 							menu.equipmentMacroData[row.index * 1000 + column] = { macro = group[i].macro, hasmod = hasmod, price = price, type = upgradetype.type }
-							if useable then
+							if onclick then
+								row[column].handlers.onClick = onclick
+							elseif useable then
 								row[column].handlers.onClick = function () return menu.buttonSelectUpgradeMacro(menu.upgradetypeMode, menu.currentSlot, group[i].macro, row.index, column, nil, (menu.mode == "customgamestart") or (menu.mode == "comparison")) end
 							end
 							if group[i].macro ~= "" then


### PR DESCRIPTION
Adds two Ship Configuration callbacks for extending available equipment data and customizing equipment upgrade buttons, while preserving native behavior when callbacks provide no override.